### PR TITLE
chore: added using keyword to typescript.ts

### DIFF
--- a/packages/core/src/rules/typescript.ts
+++ b/packages/core/src/rules/typescript.ts
@@ -12,7 +12,7 @@ const typescriptRules: ParseRule[] = [
   {
     kind: 'keyword',
     pattern:
-      /\b(as|get|set|type|namespace|infer|interface|extends|public|private|protected|implements|declare|abstract|readonly)\b/g,
+      /\b(as|get|set|type|namespace|infer|interface|extends|public|private|protected|implements|declare|abstract|readonly|using)\b/g,
   },
   ...javascriptRules,
 ];


### PR DESCRIPTION
added using keyword in typescript's keyword pattern. It'll be added in typescript 5.2
source: https://devblogs.microsoft.com/typescript/announcing-typescript-5-2-beta/